### PR TITLE
Add responsive mobile drawer

### DIFF
--- a/Education Hub/bank-statement-pdf-to-excel.html
+++ b/Education Hub/bank-statement-pdf-to-excel.html
@@ -210,6 +210,7 @@ files.download(output_file)</code></pre>
   <!-- jQuery and Bootstrap JS -->
   <script src="../lib/jquery/jquery.min.js"></script>
   <script src="../lib/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="../js/mobile-nav.js"></script>
 
   <!-- JavaScript to Load Header and Footer -->
   <script>
@@ -218,6 +219,7 @@ files.download(output_file)</code></pre>
         .then(response => response.text())
         .then(data => {
           document.getElementById("header-placeholder").innerHTML = data;
+          initMobileNav();
         })
         .catch(error => console.error("Error loading header:", error));
 

--- a/Education Hub/intro-to-python.html
+++ b/Education Hub/intro-to-python.html
@@ -166,6 +166,7 @@
   <!-- jQuery and Bootstrap JS -->
   <script src="../lib/jquery/jquery.min.js"></script>
   <script src="../lib/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="../js/mobile-nav.js"></script>
 
   <!-- JavaScript to Load Header and Footer -->
   <script>
@@ -174,6 +175,7 @@
         .then(response => response.text())
         .then(data => {
           document.getElementById("header-placeholder").innerHTML = data;
+          initMobileNav();
         })
         .catch(error => console.error("Error loading header:", error));
 

--- a/Education Hub/python-in-finance.html
+++ b/Education Hub/python-in-finance.html
@@ -159,6 +159,7 @@ print("Portfolio Risk:", portfolio_risk)</code></pre>
   <!-- jQuery and Bootstrap JS -->
   <script src="../lib/jquery/jquery.min.js"></script>
   <script src="../lib/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="../js/mobile-nav.js"></script>
 
   <!-- JavaScript to Load Header and Footer -->
   <script>
@@ -167,6 +168,7 @@ print("Portfolio Risk:", portfolio_risk)</code></pre>
         .then(response => response.text())
         .then(data => {
           document.getElementById("header-placeholder").innerHTML = data;
+          initMobileNav();
         })
         .catch(error => console.error("Error loading header:", error));
 

--- a/Education Hub/python-vat-pdf-to-excel.html
+++ b/Education Hub/python-vat-pdf-to-excel.html
@@ -226,6 +226,7 @@ for file in glob.glob("*.pdf"):
   <!-- jQuery and Bootstrap JS -->
   <script src="../lib/jquery/jquery.min.js"></script>
   <script src="../lib/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="../js/mobile-nav.js"></script>
 
   <!-- JavaScript to Load Header and Footer -->
   <script>
@@ -234,6 +235,7 @@ for file in glob.glob("*.pdf"):
         .then(response => response.text())
         .then(data => {
           document.getElementById("header-placeholder").innerHTML = data;
+          initMobileNav();
         })
         .catch(error => console.error("Error loading header:", error));
 

--- a/Education Hub/python-with-colab.html
+++ b/Education Hub/python-with-colab.html
@@ -158,6 +158,7 @@ plt.show()</code></pre>
   <!-- jQuery and Bootstrap JS -->
   <script src="../lib/jquery/jquery.min.js"></script>
   <script src="../lib/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="../js/mobile-nav.js"></script>
 
   <!-- JavaScript to Load Header and Footer -->
   <script>
@@ -166,6 +167,7 @@ plt.show()</code></pre>
         .then(response => response.text())
         .then(data => {
           document.getElementById("header-placeholder").innerHTML = data;
+          initMobileNav();
         })
         .catch(error => console.error("Error loading header:", error));
 

--- a/css/style.css
+++ b/css/style.css
@@ -67,6 +67,59 @@
   color: #0274b3;
 }
 
+#header .container {
+  position: relative;
+}
+
+#mobile-nav-toggle {
+  display: none;
+  font-size: 28px;
+  cursor: pointer;
+  position: absolute;
+  right: 20px;
+  top: 25px;
+}
+
+#side-nav {
+  position: fixed;
+  top: 0;
+  left: -250px;
+  width: 250px;
+  height: 100%;
+  background: #fff;
+  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.3);
+  overflow-y: auto;
+  transition: left 0.3s ease;
+  z-index: 998;
+  padding-top: 60px;
+}
+
+#side-nav.open {
+  left: 0;
+}
+
+#side-nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+#side-nav ul li {
+  border-bottom: 1px solid #f1f1f1;
+}
+
+#side-nav ul li a {
+  display: block;
+  padding: 12px 20px;
+  color: #555;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+#side-nav ul li a:hover {
+  background: #f5f5f5;
+}
+
 /* Responsive Header Layout Adjustments */
 @media (max-width: 768px) {
   #header {

--- a/downloads.html
+++ b/downloads.html
@@ -109,6 +109,7 @@
 
   <script src="lib/jquery/jquery.min.js"></script>
   <script src="lib/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="js/mobile-nav.js"></script>
 <script>
 // JavaScript to load header and footer
 document.addEventListener("DOMContentLoaded", function() {
@@ -116,6 +117,7 @@ document.addEventListener("DOMContentLoaded", function() {
     .then(response => response.text())
     .then(data => {
       document.getElementById("header-placeholder").innerHTML = data;
+      initMobileNav();
     });
 
   fetch("footer.html")

--- a/header.html
+++ b/header.html
@@ -52,7 +52,9 @@
           </a>
         </h1>
       </div>
-    
+
+      <div id="mobile-nav-toggle">&#9776;</div>
+
       <nav id="nav-menu-container">
         <ul class="nav-menu">
           <li class="menu-active"><a href="../index.html">Home</a></li>
@@ -63,3 +65,12 @@
       </nav>
     </div>
   </header>
+
+  <div id="side-nav">
+    <ul>
+      <li><a href="../index.html">Home</a></li>
+      <li><a href="../index.html#about">About Us</a></li>
+      <li><a href="../index.html#services">Services</a></li>
+      <li><a href="../index.html#contact">Contact</a></li>
+    </ul>
+  </div>

--- a/js/mobile-nav.js
+++ b/js/mobile-nav.js
@@ -1,0 +1,22 @@
+function initMobileNav() {
+  var toggle = document.getElementById('mobile-nav-toggle');
+  var sideNav = document.getElementById('side-nav');
+  if (!toggle || !sideNav) return;
+
+  toggle.addEventListener('click', function(event) {
+    event.stopPropagation();
+    sideNav.classList.toggle('open');
+  });
+
+  sideNav.querySelectorAll('a').forEach(function(link) {
+    link.addEventListener('click', function() {
+      sideNav.classList.remove('open');
+    });
+  });
+
+  document.addEventListener('click', function(e) {
+    if (!sideNav.contains(e.target) && e.target !== toggle) {
+      sideNav.classList.remove('open');
+    }
+  });
+}

--- a/knowledge-hub.html
+++ b/knowledge-hub.html
@@ -165,12 +165,14 @@
   <!-- Load Header and Footer -->
   <script src="lib/jquery/jquery.min.js"></script>
   <script src="lib/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="js/mobile-nav.js"></script>
   <script>
     document.addEventListener("DOMContentLoaded", function() {
       fetch("header.html")
         .then(response => response.text())
         .then(data => {
           document.getElementById("header-placeholder").innerHTML = data;
+          initMobileNav();
         });
 
       fetch("footer.html")

--- a/news.html
+++ b/news.html
@@ -118,6 +118,7 @@
 
   <script src="lib/jquery/jquery.min.js"></script>
   <script src="lib/bootstrap/js/bootstrap.bundle.min.js"></script>
+  <script src="js/mobile-nav.js"></script>
 <script>
 // JavaScript to load header and footer
 document.addEventListener("DOMContentLoaded", function() {
@@ -125,6 +126,7 @@ document.addEventListener("DOMContentLoaded", function() {
     .then(response => response.text())
     .then(data => {
       document.getElementById("header-placeholder").innerHTML = data;
+      initMobileNav();
     });
 
   fetch("footer.html")


### PR DESCRIPTION
## Summary
- add side-nav markup and hamburger toggle in header snippet
- implement side navigation behavior with vanilla JS
- style mobile navigation drawer in CSS
- load drawer script from pages that include header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684018914f608324ab85314572977e52